### PR TITLE
Use `setfenv` for globals

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,7 +1,7 @@
 import { Reconciler } from "./Reconciler";
 
 /** A function that gets called when a VirtualScript is executed. */
-export type Executor = () => unknown;
+export type Executor = (globals: VirtualEnv) => unknown;
 
 /** Base environment for VirtualScript instances. */
 export interface VirtualEnv {

--- a/src/globals/rostruct-globals.ts
+++ b/src/globals/rostruct-globals.ts
@@ -10,15 +10,11 @@ import { VirtualEnv } from "core";
 interface Globals {
 	/** A number used to identify Reconciler objects. */
 	currentScope: number;
-
-	/** List of environments for running VirtualScripts. */
-	environments: Map<string, VirtualEnv>;
 }
 
 /** Global environment reserved for Rostruct. */
 export const globals: Globals = (getgenv().Rostruct as Globals) || {
 	currentScope: 0,
-	environments: new Map<string, VirtualEnv>(),
 };
 
 getgenv().Rostruct = globals;


### PR DESCRIPTION
Instead of using `getgenv` to access globals, set globals using `setfenv` and the `...` expression set when calling a loaded chunk:
```lua
setfenv(1, setmetatable(..., { __index = getfenv(0) }));
```

Resolves #12 